### PR TITLE
Fix homepage and repository links on crates.io and lib.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ description = "MacBinary and resource fork parser"
 keywords = ["macos", "retro", "computing", "no_std"]
 categories = ["parser-implementations", "encoding", "wasm", "no-std"]
 
-homepage = "https://github.com/wezm/rsspls"
-repository = "https://github.com/wezm/rsspls.git"
+homepage = "https://7bit.org/macbinary/"
+repository = "https://github.com/wezm/macbinary"
 
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Cargo.toml currently points to RSS Please as the macbinary crate's website and repository.

This PR changes the repository link to the proper one and, in line with established convention, resolves "`homepage` is functionally a duplicate of `repository`" by pointing it at the same URL as the GitHub repository lists for its homepage link.